### PR TITLE
feat: Add configurable warning behavior with summary mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,9 @@ These flags can be used with any command.
     -   **Example:** `--navidrome-username admin`
 -   `--navidrome-password <password>`: Your Navidrome password.
     -   **Example:** `--navidrome-password your_navidrome_password`
+-   `--warnings <mode>`: Controls how warnings are displayed during downloads.
+    -   **Modes:** `summary` (default), `immediate`, `silent`
+    -   **Example:** `--warnings immediate` for real-time warnings, `--warnings silent` for clean output
 
 ### Command-Specific Flags
 

--- a/musicbrainz.go
+++ b/musicbrainz.go
@@ -14,21 +14,59 @@ const (
 	musicBrainzUserAgent = "dab-downloader/2.0 ( prathxm.in@gmail.com )" // Replace with your actual email or project contact
 )
 
+// MusicBrainzConfig holds retry configuration for MusicBrainz API calls
+type MusicBrainzConfig struct {
+	MaxRetries    int           `json:"max_retries"`
+	InitialDelay  time.Duration `json:"initial_delay"`
+	MaxDelay      time.Duration `json:"max_delay"`
+}
+
+// DefaultMusicBrainzConfig returns sensible defaults for MusicBrainz API retry behavior
+func DefaultMusicBrainzConfig() MusicBrainzConfig {
+	return MusicBrainzConfig{
+		MaxRetries:   5,
+		InitialDelay: 2 * time.Second,
+		MaxDelay:     60 * time.Second,
+	}
+}
+
 // MusicBrainzClient for making requests to the MusicBrainz API
 type MusicBrainzClient struct {
 	client *http.Client
+	config MusicBrainzConfig
 }
 
-// NewMusicBrainzClient creates a new MusicBrainz API client
+// NewMusicBrainzClient creates a new MusicBrainz API client with default retry configuration
 func NewMusicBrainzClient() *MusicBrainzClient {
 	return &MusicBrainzClient{
 		client: &http.Client{
 			Timeout: 30 * time.Second, // MusicBrainz API can be slow
 		},
+		config: DefaultMusicBrainzConfig(),
 	}
 }
 
-// get makes a GET request to the MusicBrainz API
+// NewMusicBrainzClientWithConfig creates a new MusicBrainz API client with custom retry configuration
+func NewMusicBrainzClientWithConfig(config MusicBrainzConfig) *MusicBrainzClient {
+	return &MusicBrainzClient{
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		config: config,
+	}
+}
+
+// UpdateRetryConfig updates the retry configuration for the client
+func (mb *MusicBrainzClient) UpdateRetryConfig(config MusicBrainzConfig) {
+	mb.config = config
+}
+
+// GetRetryConfig returns the current retry configuration
+func (mb *MusicBrainzClient) GetRetryConfig() MusicBrainzConfig {
+	return mb.config
+}
+
+// get makes a GET request to the MusicBrainz API (internal method without retry)
 func (mb *MusicBrainzClient) get(path string) ([]byte, error) {
 	req, err := http.NewRequest("GET", musicBrainzAPI+path, nil)
 	if err != nil {
@@ -44,7 +82,17 @@ func (mb *MusicBrainzClient) get(path string) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("MusicBrainz API request failed with status: %s", resp.Status)
+		// Create structured HTTP error for retry logic
+		body, _ := ioutil.ReadAll(resp.Body)
+		message := string(body)
+		if len(message) > 200 {
+			message = message[:200] + "..."
+		}
+		return nil, &HTTPError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Message:    message,
+		}
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -54,10 +102,31 @@ func (mb *MusicBrainzClient) get(path string) ([]byte, error) {
 	return body, nil
 }
 
+// getWithRetry makes a GET request to the MusicBrainz API with retry logic for retryable errors
+func (mb *MusicBrainzClient) getWithRetry(path string) ([]byte, error) {
+	var result []byte
+	var err error
+
+	retryErr := RetryWithBackoffForHTTP(
+		mb.config.MaxRetries,
+		mb.config.InitialDelay,
+		mb.config.MaxDelay,
+		func() error {
+			result, err = mb.get(path)
+			return err
+		},
+	)
+
+	if retryErr != nil {
+		return nil, retryErr
+	}
+	return result, nil
+}
+
 // GetTrackMetadata fetches track metadata from MusicBrainz by MBID
 func (mb *MusicBrainzClient) GetTrackMetadata(mbid string) (*MusicBrainzTrack, error) {
 	path := fmt.Sprintf("recording/%s?inc=artists+releases+url-rels", mbid)
-	body, err := mb.get(path)
+	body, err := mb.getWithRetry(path)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +141,7 @@ func (mb *MusicBrainzClient) GetTrackMetadata(mbid string) (*MusicBrainzTrack, e
 // GetReleaseMetadata fetches release (album) metadata from MusicBrainz by MBID
 func (mb *MusicBrainzClient) GetReleaseMetadata(mbid string) (*MusicBrainzRelease, error) {
 	path := fmt.Sprintf("release/%s?inc=artists+labels+recordings+url-rels+release-groups", mbid)
-	body, err := mb.get(path)
+	body, err := mb.getWithRetry(path)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +157,7 @@ func (mb *MusicBrainzClient) GetReleaseMetadata(mbid string) (*MusicBrainzReleas
 func (mb *MusicBrainzClient) SearchTrack(artist, album, title string) (*MusicBrainzTrack, error) {
 	query := fmt.Sprintf("artist:\"%s\" AND release:\"%s\" AND recording:\"%s\"", artist, album, title)
 	path := fmt.Sprintf("recording?query=%s&limit=1", url.QueryEscape(query))
-	body, err := mb.get(path)
+	body, err := mb.getWithRetry(path)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +180,7 @@ func (mb *MusicBrainzClient) SearchTrack(artist, album, title string) (*MusicBra
 func (mb *MusicBrainzClient) SearchRelease(artist, album string) (*MusicBrainzRelease, error) {
 	query := fmt.Sprintf("artist:\"%s\" AND release:\"%s\"", artist, album)
 	path := fmt.Sprintf("release?query=%s&limit=1", url.QueryEscape(query))
-	body, err := mb.get(path)
+	body, err := mb.getWithRetry(path)
 	if err != nil {
 		return nil, err
 	}

--- a/retry.go
+++ b/retry.go
@@ -2,9 +2,36 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
+	"net/http"
 	"time"
 )
+
+// HTTPError represents an HTTP error with status code
+type HTTPError struct {
+	StatusCode int
+	Status     string
+	Message    string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s - %s", e.StatusCode, e.Status, e.Message)
+}
+
+// IsRetryableHTTPError checks if an HTTP error should be retried
+func IsRetryableHTTPError(err error) bool {
+	if httpErr, ok := err.(*HTTPError); ok {
+		switch httpErr.StatusCode {
+		case http.StatusServiceUnavailable, // 503
+			http.StatusTooManyRequests,     // 429
+			http.StatusBadGateway,          // 502
+			http.StatusGatewayTimeout:      // 504
+			return true
+		}
+	}
+	return false
+}
 
 // RetryWithBackoff retries the given function with exponential backoff.
 func RetryWithBackoff(maxRetries int, initialDelaySec int, fn func() error) error {
@@ -21,4 +48,46 @@ func RetryWithBackoff(maxRetries int, initialDelaySec int, fn func() error) erro
 		time.Sleep(delay + jitter)
 	}
 	return fmt.Errorf("failed after %d attempts: %w", maxRetries, err)
+}
+
+// RetryWithBackoffForHTTP retries HTTP requests with smart error handling
+func RetryWithBackoffForHTTP(maxRetries int, initialDelay time.Duration, maxDelay time.Duration, fn func() error) error {
+	var lastErr error
+	
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+
+		// Check if this is a retryable HTTP error
+		if !IsRetryableHTTPError(lastErr) {
+			return lastErr // Don't retry non-retryable errors
+		}
+
+		if attempt == maxRetries-1 {
+			break // Don't sleep on the last attempt
+		}
+
+		// Calculate delay with exponential backoff and jitter
+		delay := initialDelay * time.Duration(1<<uint(attempt))
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+		
+		// Add jitter (±25% of delay)
+		jitter := time.Duration(rand.Int63n(int64(delay/2))) - delay/4
+		finalDelay := delay + jitter
+		
+		if finalDelay < 0 {
+			finalDelay = delay
+		}
+
+		log.Printf("HTTP request failed (attempt %d/%d): %v. Retrying in %v", 
+			attempt+1, maxRetries, lastErr, finalDelay)
+		
+		time.Sleep(finalDelay)
+	}
+	
+	return fmt.Errorf("failed after %d attempts: %w", maxRetries, lastErr)
 }

--- a/types.go
+++ b/types.go
@@ -32,6 +32,7 @@ type Config struct {
 	NamingMasks         NamingOptions `json:"naming"`
 	VerifyDownloads     bool `json:"VerifyDownloads"` // Enable/disable download verification
 	MaxRetryAttempts    int  `json:"MaxRetryAttempts"` // Configurable retry attempts
+	WarningBehavior     string `json:"WarningBehavior"` // "immediate", "summary", or "silent"
 }
 
 // NamingOptions defines the configurable naming masks

--- a/warning_collector.go
+++ b/warning_collector.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// WarningType represents different types of warnings
+type WarningType int
+
+const (
+	MusicBrainzTrackWarning WarningType = iota
+	MusicBrainzReleaseWarning
+	CoverArtDownloadWarning
+	CoverArtMetadataWarning
+	AlbumFetchWarning
+	TrackSkippedWarning
+)
+
+// Warning represents a single warning with context
+type Warning struct {
+	Type     WarningType
+	Message  string
+	Context  string // Track/Album context
+	Details  string // Additional details like error message
+}
+
+// WarningCollector collects warnings during download operations
+type WarningCollector struct {
+	warnings []Warning
+	enabled  bool
+}
+
+// NewWarningCollector creates a new warning collector
+func NewWarningCollector(enabled bool) *WarningCollector {
+	return &WarningCollector{
+		warnings: make([]Warning, 0),
+		enabled:  enabled,
+	}
+}
+
+// AddWarning adds a warning to the collector
+func (wc *WarningCollector) AddWarning(warningType WarningType, context, message, details string) {
+	if !wc.enabled {
+		return
+	}
+	
+	warning := Warning{
+		Type:    warningType,
+		Message: message,
+		Context: context,
+		Details: details,
+	}
+	wc.warnings = append(wc.warnings, warning)
+}
+
+// AddMusicBrainzTrackWarning adds a MusicBrainz track lookup warning
+func (wc *WarningCollector) AddMusicBrainzTrackWarning(artist, title, details string) {
+	context := fmt.Sprintf("%s - %s", artist, title)
+	wc.AddWarning(MusicBrainzTrackWarning, context, "Failed to find MusicBrainz track", details)
+}
+
+// AddMusicBrainzReleaseWarning adds a MusicBrainz release lookup warning
+func (wc *WarningCollector) AddMusicBrainzReleaseWarning(artist, album, details string) {
+	context := fmt.Sprintf("%s - %s", artist, album)
+	wc.AddWarning(MusicBrainzReleaseWarning, context, "Failed to find MusicBrainz release", details)
+}
+
+// AddCoverArtDownloadWarning adds a cover art download warning
+func (wc *WarningCollector) AddCoverArtDownloadWarning(album, details string) {
+	wc.AddWarning(CoverArtDownloadWarning, album, "Could not download cover art", details)
+}
+
+// AddCoverArtMetadataWarning adds a cover art metadata warning
+func (wc *WarningCollector) AddCoverArtMetadataWarning(context, details string) {
+	wc.AddWarning(CoverArtMetadataWarning, context, "Failed to add cover art to metadata", details)
+}
+
+// AddAlbumFetchWarning adds an album fetch warning
+func (wc *WarningCollector) AddAlbumFetchWarning(trackTitle, trackID, details string) {
+	context := fmt.Sprintf("%s (ID: %s)", trackTitle, trackID)
+	wc.AddWarning(AlbumFetchWarning, context, "Could not fetch album info", details)
+}
+
+// AddTrackSkippedWarning adds a track skipped warning
+func (wc *WarningCollector) AddTrackSkippedWarning(trackPath string) {
+	wc.AddWarning(TrackSkippedWarning, trackPath, "Track already exists", "")
+}
+
+// HasWarnings returns true if there are any warnings
+func (wc *WarningCollector) HasWarnings() bool {
+	return len(wc.warnings) > 0
+}
+
+// GetWarningCount returns the total number of warnings
+func (wc *WarningCollector) GetWarningCount() int {
+	return len(wc.warnings)
+}
+
+// GetWarningsByType returns warnings grouped by type
+func (wc *WarningCollector) GetWarningsByType() map[WarningType][]Warning {
+	grouped := make(map[WarningType][]Warning)
+	for _, warning := range wc.warnings {
+		grouped[warning.Type] = append(grouped[warning.Type], warning)
+	}
+	return grouped
+}
+
+// PrintSummary prints a formatted summary of all warnings
+func (wc *WarningCollector) PrintSummary() {
+	if !wc.HasWarnings() {
+		return
+	}
+
+	colorWarning.Printf("\n⚠️  Warning Summary (%d warnings):\n", len(wc.warnings))
+	colorWarning.Println(strings.Repeat("─", 50))
+
+	grouped := wc.GetWarningsByType()
+	
+	// Sort warning types for consistent output
+	var types []WarningType
+	for warningType := range grouped {
+		types = append(types, warningType)
+	}
+	sort.Slice(types, func(i, j int) bool { return types[i] < types[j] })
+
+	for _, warningType := range types {
+		warnings := grouped[warningType]
+		wc.printWarningTypeSection(warningType, warnings)
+	}
+}
+
+// printWarningTypeSection prints warnings for a specific type
+func (wc *WarningCollector) printWarningTypeSection(warningType WarningType, warnings []Warning) {
+	if len(warnings) == 0 {
+		return
+	}
+
+	// Print section header
+	sectionTitle := wc.getWarningTypeTitle(warningType)
+	colorWarning.Printf("\n%s (%d):\n", sectionTitle, len(warnings))
+
+	// Group similar warnings to avoid repetition
+	contextCounts := make(map[string]int)
+	for _, warning := range warnings {
+		contextCounts[warning.Context]++
+	}
+
+	// Sort contexts for consistent output
+	var contexts []string
+	for context := range contextCounts {
+		contexts = append(contexts, context)
+	}
+	sort.Strings(contexts)
+
+	// Print warnings, showing count if multiple
+	for _, context := range contexts {
+		count := contextCounts[context]
+		if count > 1 {
+			colorWarning.Printf("  • %s (×%d)\n", context, count)
+		} else {
+			colorWarning.Printf("  • %s\n", context)
+		}
+	}
+}
+
+// getWarningTypeTitle returns a human-readable title for a warning type
+func (wc *WarningCollector) getWarningTypeTitle(warningType WarningType) string {
+	switch warningType {
+	case MusicBrainzTrackWarning:
+		return "MusicBrainz Track Lookup Failures"
+	case MusicBrainzReleaseWarning:
+		return "MusicBrainz Release Lookup Failures"
+	case CoverArtDownloadWarning:
+		return "Cover Art Download Failures"
+	case CoverArtMetadataWarning:
+		return "Cover Art Metadata Failures"
+	case AlbumFetchWarning:
+		return "Album Information Fetch Failures"
+	case TrackSkippedWarning:
+		return "Tracks Skipped (Already Exist)"
+	default:
+		return "Other Warnings"
+	}
+}


### PR DESCRIPTION
- Add warning collector system to suppress noisy warnings during downloads
- Implement three warning modes: 'summary' (default), 'immediate', 'silent'
- Collect MusicBrainz lookup failures, cover art errors, and skipped tracks
- Display organized warning summary at end of operations instead of inline
- Add --warnings flag for temporary behavior override
- Update all download functions to use shared warning collector
- Show warning summary before download statistics for better UX
- Maintain backward compatibility with existing immediate warning behavior